### PR TITLE
Add route to connect to cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 .byebug_history
 .env
 .idea
+.env*local

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem 'capybara'
   gem 'dotenv-rails'
   gem 'selenium-webdriver'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.4)
     dotenv (2.8.1)
@@ -121,6 +123,7 @@ GEM
       sanitize (< 7)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -242,6 +245,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -273,6 +280,7 @@ DEPENDENCIES
   spring-watcher-listen
   sqlite3
   web-console
+  webmock
 
 BUNDLED WITH
    2.3.21

--- a/app/controllers/cloud_controller.rb
+++ b/app/controllers/cloud_controller.rb
@@ -1,16 +1,18 @@
 class CloudController < ApplicationController
   def connect
+    token = EncryptedToken.decrypt(params[:token])
+
     # Get flipper instance using the given token
-    flipper = Flipper::Middleware::Session.configure(session, token: params[:token])
+    flipper = Flipper::Middleware::Session.configure(session, token: token)
 
     # Sync will fail on invalid tokens
     flipper.sync
 
     # Save the token in the session
-    session[:cloud_token] = params[:token]
+    session[:cloud_token] = token
 
     redirect_back_or_to root_path, notice: "Connected to Flipper Cloud!"
-  rescue Flipper::Adapters::Http::Error
+  rescue EncryptedToken::Invalid, Flipper::Adapters::Http::Error
     render plain: "Invalid token", status: :not_acceptable
   end
 end

--- a/app/controllers/cloud_controller.rb
+++ b/app/controllers/cloud_controller.rb
@@ -1,0 +1,16 @@
+class CloudController < ApplicationController
+  def connect
+    # Get flipper instance using the given token
+    flipper = Flipper::Middleware::Session.configure(session, token: params[:token])
+
+    # Sync will fail on invalid tokens
+    flipper.sync
+
+    # Save the token in the session
+    session[:cloud_token] = params[:token]
+
+    redirect_back_or_to root_path, notice: "Connected to Flipper Cloud!"
+  rescue Flipper::Adapters::Http::Error
+    render plain: "Invalid token", status: :not_acceptable
+  end
+end

--- a/app/models/encrypted_token.rb
+++ b/app/models/encrypted_token.rb
@@ -1,8 +1,9 @@
 # Helper to get an encrypted token from Cloud and securely store it in the session
 class EncryptedToken
   MESSAGE_ENCRYPTER = ActiveSupport::MessageEncryptor.new(
-    Rails.application.key_generator(ENV["DEMO_SHARED_KEY"] || "demo").
-      generate_key("cloud-token", ActiveSupport::MessageEncryptor.key_len),
+    ActiveSupport::KeyGenerator.new(ENV["DEMO_SHARED_KEY"] || "demo").generate_key(
+      "encrypted-token", ActiveSupport::MessageEncryptor.key_len
+    ),
     url_safe: true
   )
 

--- a/app/models/encrypted_token.rb
+++ b/app/models/encrypted_token.rb
@@ -1,0 +1,20 @@
+# Helper to get an encrypted token from Cloud and securely store it in the session
+class EncryptedToken
+  MESSAGE_ENCRYPTER = ActiveSupport::MessageEncryptor.new(
+    Rails.application.key_generator(ENV["DEMO_SHARED_KEY"] || "demo").
+      generate_key("cloud-token", ActiveSupport::MessageEncryptor.key_len),
+    url_safe: true
+  )
+
+  Invalid = Class.new(StandardError)
+
+  def self.decrypt(data, ...)
+    MESSAGE_ENCRYPTER.decrypt_and_verify(data, ...) || raise(Invalid)
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    raise Invalid
+  end
+
+  def self.encrypt(value, ...)
+    MESSAGE_ENCRYPTER.encrypt_and_sign(value, ...)
+  end
+end

--- a/app/models/encrypted_token.rb
+++ b/app/models/encrypted_token.rb
@@ -1,7 +1,7 @@
 # Helper to get an encrypted token from Cloud and securely store it in the session
 class EncryptedToken
   MESSAGE_ENCRYPTER = ActiveSupport::MessageEncryptor.new(
-    ActiveSupport::KeyGenerator.new(ENV["DEMO_SHARED_KEY"] || "demo").generate_key(
+    ActiveSupport::KeyGenerator.new(ENV["PLAYGROUND_SHARED_KEY"] || "demo").generate_key(
       "encrypted-token", ActiveSupport::MessageEncryptor.key_len
     ),
     url_safe: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get 'demo/percentage'
 
 
+  get 'connect/:token', to: "cloud#connect", as: :cloud_connect
+
   # The Flipper UI gem interface.
   #
   # IMPORTANT: In production, you'd want to limit access to this, or anybody would be able to

--- a/lib/flipper/middleware/session.rb
+++ b/lib/flipper/middleware/session.rb
@@ -1,3 +1,5 @@
+require "flipper/cloud"
+
 # Middleware to configure flipper to use the Session adapter before each request
 class Flipper::Middleware::Session
   def initialize(app, env_key: 'flipper')
@@ -7,9 +9,29 @@ class Flipper::Middleware::Session
 
   def call(env)
     original_instance = Flipper.instance
-    env[@env_key] = Flipper.instance = Flipper.new(Flipper::Adapters::Session.new(env['rack.session']))
+
+    env[@env_key] = Flipper.instance = self.class.configure(env['rack.session'])
+
+    # Sync before making request
+    Flipper.sync
+
     @app.call(env)
   ensure
     Flipper.instance = original_instance
+  end
+
+  # Returns a Flipper instance using the given session
+  def self.configure(session, token: session[:cloud_token])
+    adapter = Flipper::Adapters::Session.new(session)
+
+    if token
+      Flipper::Cloud.new(
+        token: token,
+        local_adapter: adapter,
+        sync_secret: "disable polling"
+      ).tap(&:sync)
+    else
+      Flipper.new(adapter)
+    end
   end
 end

--- a/lib/flipper/middleware/session.rb
+++ b/lib/flipper/middleware/session.rb
@@ -29,7 +29,7 @@ class Flipper::Middleware::Session
         token: token,
         local_adapter: adapter,
         sync_secret: "disable polling"
-      ).tap(&:sync)
+      )
     else
       Flipper.new(adapter)
     end

--- a/test/controllers/cloud_controller_test.rb
+++ b/test/controllers/cloud_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class CloudControllerTest < ActionDispatch::IntegrationTest
+  test "connect with valid token" do
+    stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
+      to_return(status: 200, body: '{"features": {}}')
+
+    get cloud_connect_url("valid personal token")
+    assert_redirected_to root_url
+  end
+
+  test "connect with invalid token" do
+    stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
+      to_return(status: 401, body: '{"error": "invalid token"}')
+
+    get cloud_connect_url('invalid')
+    assert_response 406
+    assert_select '*', text: /invalid/i
+  end
+end

--- a/test/controllers/cloud_controller_test.rb
+++ b/test/controllers/cloud_controller_test.rb
@@ -2,18 +2,28 @@ require "test_helper"
 
 class CloudControllerTest < ActionDispatch::IntegrationTest
   test "connect with valid token" do
+    token = "valid personal token"
     stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
+      with(headers: { 'Flipper-Cloud-Token' => token }).
       to_return(status: 200, body: '{"features": {}}')
 
-    get cloud_connect_url("valid personal token")
+    get cloud_connect_url(EncryptedToken.encrypt(token))
     assert_redirected_to root_url
   end
 
+  test "connect with expired token" do
+    get cloud_connect_url(EncryptedToken.encrypt('invalid', expires_at: 1.second.ago))
+    assert_response 406
+    assert_select '*', text: /invalid/i
+  end
+
   test "connect with invalid token" do
+    token = 'invalid'
     stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
+      with(headers: { 'Flipper-Cloud-Token' => token }).
       to_return(status: 401, body: '{"error": "invalid token"}')
 
-    get cloud_connect_url('invalid')
+    get cloud_connect_url(EncryptedToken.encrypt(token))
     assert_response 406
     assert_select '*', text: /invalid/i
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'webmock/minitest'
 
 # Override Flipper Cloud configuration for tests
 # Read more about testing with Flipper Cloud:


### PR DESCRIPTION
This adds `/connect/:token` route to configure a Flipper Cloud token and saves it in the session. It uses a preshared key to encrypt and sign the token in transit, so we can set expiry on them and not have to worry as much about replay attacks.